### PR TITLE
Improve performance.

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -576,6 +576,7 @@ LRESULT CSearchDlg::DlgFunc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
         break;
     case SEARCH_END:
         {
+            AddFoundEntry(NULL, true);
             AutoSizeAllColumns();
             UpdateInfoLabel(false);
             ::SetDlgItemText(*this, IDOK, TranslatedString(hResource, IDS_SEARCH).c_str());
@@ -589,7 +590,10 @@ LRESULT CSearchDlg::DlgFunc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
     case WM_TIMER:
         {
             if (wParam == LABELUPDATETIMER)
+            {
+                AddFoundEntry(NULL, true);
                 UpdateInfoLabel(true);
+            }
         }
         break;
     case WM_HELP:
@@ -1242,9 +1246,12 @@ bool CSearchDlg::AddFoundEntry(CSearchInfo * pInfo, bool bOnlyListControl)
             ++subIndex;
         }
     }
-    HWND hListControl = GetDlgItem(*this, IDC_RESULTLIST);
-    bool filelist = (IsDlgButtonChecked(*this, IDC_RESULTFILES) == BST_CHECKED);
-    ListView_SetItemCount(hListControl, filelist ? m_items.size() : m_listItems.size());
+    else
+    {
+        HWND hListControl = GetDlgItem(*this, IDC_RESULTLIST);
+        bool filelist = (IsDlgButtonChecked(*this, IDC_RESULTFILES) == BST_CHECKED);
+        ListView_SetItemCount(hListControl, filelist ? m_items.size() : m_listItems.size());
+    }
     return true;
 }
 


### PR DESCRIPTION
**Case**

If you have a lot of files to search and have a lot of matches (results), the call of the function `ListView_SetItemCount` on the list control (`IDC_RESULTLIST`) will slow down the search speed (a lot).

![2018-08-14_15-33-10](https://user-images.githubusercontent.com/2457338/44110923-6ff7ff64-9fd7-11e8-9496-9b4e07459f9b.gif)

(As I'm recording the screen, the problem is even more evident.)
(If you minimize the window during the search you will get a much faster result)

**Proposal**

Avoid update the `IDC_RESULTLIST` on every match found.

![2018-08-14_15-30-31](https://user-images.githubusercontent.com/2457338/44110938-77ca636c-9fd7-11e8-96fa-513265616fa7.gif)

**Solution**
I did a quick workaround to update it every 200 ms along with the `LABELUPDATETIMER` and on the `SEARCH_END` event.

**Notes**

I did this way because I thought it simpler, so, feel free to change if you want.


