### PR TITLE
fix thread handle leak

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -109,7 +109,6 @@ CSearchDlg::CSearchDlg(HWND hParent)
     , m_Date1({0})
     , m_Date2({0})
     , m_bDateLimitC(false)
-    , m_hSearchThread(NULL)
     , m_regUseRegex(_T("Software\\grepWin\\UseRegex"), 1)
     , m_regAllSize(_T("Software\\grepWin\\AllSize"))
     , m_regSize(_T("Software\\grepWin\\Size"), 2000)
@@ -802,13 +801,23 @@ LRESULT CSearchDlg::DoCommand(int id, int msg)
                 SendDlgItemMessage(*this, IDC_PROGRESS, PBM_SETMARQUEE, 1, 0);
                 // now start the thread which does the searching
                 DWORD dwThreadId = 0;
-                m_hSearchThread = CreateThread(
+                HANDLE hThread= CreateThread(
                     NULL,              // no security attribute
                     0,                 // default stack size
                     SearchThreadEntry,
                     (LPVOID)this,      // thread parameter
                     0,                 // not suspended
                     &dwThreadId);      // returns thread ID
+                if (hThread != nullptr)
+                {
+                    // Closing the handle of a running thread just decreases
+                    // the ref count for the thread object.
+                    CloseHandle(hThread);
+                }
+                else
+                {
+                    SendMessage(*this, SEARCH_END, 0, 0);
+                }
             }
         }
         break;

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -166,7 +166,6 @@ private:
     bool                    m_bConfirmationOnReplace;
     bool                    m_showContent;
     bool                    m_showContentSet;
-    HANDLE                  m_hSearchThread;
 
     std::vector<CSearchInfo> m_items;
     std::vector<std::tuple<int, int>> m_listItems;


### PR DESCRIPTION
After creating a search thread, grepWin never closes the associated handle. So with every search a zombie thread object remains lingering. I suggest to close the thread handle immediately after creating the thread (analogous to the standard usage of CreateProcess).