### PR TITLE
Add support for jump to line with Visual Studio Code

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -1996,10 +1996,10 @@ void CSearchDlg::OpenFileAtListIndex(int listIndex)
     }
     if (!linenumberparam.empty())
     {
-		if (!linenumberparam.starts_with(L":"))
-		{
+        if (!linenumberparam.starts_with(L":"))
+        {
             application += _T(" ");
-		}
+        }
         application += linenumberparam;
     }
 

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -1962,6 +1962,12 @@ void CSearchDlg::OpenFileAtListIndex(int listIndex)
         // BowPad
         linenumberparam = CStringUtils::Format(L"/line:%s", textlinebuf);
     }
+	else if (appname.find(_T("code.exe")) != std::wstring::npos)
+    {
+        // Visual Studio Code
+        linenumberparam_before = L"--goto";
+        linenumberparam = CStringUtils::Format(L":%s", textlinebuf);
+    }
 
     // replace "%1" with %1
     std::wstring           tag      = _T("\"%1\"");
@@ -1990,7 +1996,10 @@ void CSearchDlg::OpenFileAtListIndex(int listIndex)
     }
     if (!linenumberparam.empty())
     {
-        application += _T(" ");
+		if (!linenumberparam.starts_with(L":"))
+		{
+            application += _T(" ");
+		}
         application += linenumberparam;
     }
 


### PR DESCRIPTION
Hello :) 

My proposed change is to add jump-to-line for Visual Studio Code (VSCode). 

I used grepWin a ton on .json and .xml files, which I have open in VSCode by default. I believe having automatic jump to line would be incredibly useful while navigating through search results. 

This is my first contribution to this project, please let me know if I am missing anything :) 

