### PR TITLE
Update Japanese translation 2.0.3 2nd ed

### DIFF
--- a/translations/Japanese.lang
+++ b/translations/Japanese.lang
@@ -101,7 +101,7 @@ msgstr "キャンセル"
 
 #. Resource IDs: (169)
 msgid "Capture search"
-msgstr "Capture 検索"
+msgstr "キャプチャと後方参照を使用"
 
 #. Resource IDs: (1088)
 msgid "Check for updates"
@@ -233,7 +233,7 @@ msgstr "隠し属性ファイルを含める"
 
 #. Resource IDs: (1062)
 msgid "Include search path"
-msgstr "検索パスを含める"
+msgstr "検索場所も保存"
 
 #. Resource IDs: (1011)
 msgid "Include subfolders"
@@ -374,7 +374,7 @@ msgstr "置換文字列"
 
 #. Resource IDs: (1027)
 msgid "Replace with/\nCapture format:"
-msgstr "置換文字列(&H)/\nCapture format:"
+msgstr "置換文字列(&H)/\n後方参照:"
 
 #. Resource IDs: (126)
 msgid "S&top"


### PR DESCRIPTION
I'm sorry for repeating myself. I understand "Capture".

Assign the "Replace with" shortcut ```R``` by the previous translator Tilt. But, this was changed to ```H``` because of the conflict.