### PR TITLE
Fix capitalization in Help file

### DIFF
--- a/src/Resources/infodlg.htm
+++ b/src/Resources/infodlg.htm
@@ -67,7 +67,7 @@
 </head>
 
 <body>
-    <p>this help file shows only the basics of a regular expression search, and
+    <p>This help file shows only the basics of a regular expression search, and
         it's here only to show the flavor of the used regex.</p>
     <p>If you're not familiar with regular expressions, please consult
         a tutorial like <a href="https://www.regular-expressions.info/tutorial.html"


### PR DESCRIPTION
Change: "**this** help file shows only the basics of a regular expression search..."
to: "**This** help file shows only the basics of a regular expression search..."