### PR TITLE
Update Dutch.lang

### DIFF
--- a/translations/Dutch.lang
+++ b/translations/Dutch.lang
@@ -340,10 +340,6 @@ msgstr "Naam Voorinstelling"
 msgid "Presets"
 msgstr "Voorinstellingen"
 
-#. Resource IDs: (132)
-msgid "Presets"
-msgstr "Voorinstellingen"
-
 #. Resource IDs: (1065)
 msgid "Press F1 for help"
 msgstr "Druk op F1 voor hulp"


### PR DESCRIPTION
Removed three superfluous lines 343-345
redefinition of IDs 132

BTW, I discovered that IDs 65535 is defined twice at lines 469 and 473. This is in English as well as in Dutch. Is this correct?