### PR TITLE
Upper-case first letter of context menu

### DIFF
--- a/src/ExplorerCommandVerb/dllmain.cpp
+++ b/src/ExplorerCommandVerb/dllmain.cpp
@@ -217,7 +217,7 @@ class __declspec(uuid("3C557AFF-6181-4BBC-937D-E2FE8844DD49")) GrepWinExplorerCo
 public:
     const wchar_t* Title(IShellItemArray*) override
     {
-        return L"search with grepWin";
+        return L"Search with grepWin";
     }
 
     EXPCMDSTATE State(_In_opt_ IShellItemArray* ) override

--- a/src/Setup/Setup.wxs
+++ b/src/Setup/Setup.wxs
@@ -81,27 +81,27 @@
             <File Id="Spanish_Mexican.lang" Name="Spanish Mexican.lang" DiskId="1" Source="../../translations/Spanish Mexican.lang" />
             <File Id="Hindi.lang" Name="Hindi.lang" DiskId="1" Source="../../translations/Hindi.lang" />
             <RegistryKey Root="HKMU" Key="Software\Classes\Directory\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\Directory\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\Directory\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Directory\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%1"' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Directory\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%V"' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%V"' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\Folder\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\Folder\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\Folder\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Folder\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Folder\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%1"' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\Drive\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\Drive\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\Drive\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Drive\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Drive\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%1"' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\*\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%1"' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin" Name="MultiSelectModel" Value='Player' Type="string" />

--- a/src/Setup/Setup64.wxs
+++ b/src/Setup/Setup64.wxs
@@ -102,27 +102,27 @@
             <File Id="Spanish_Mexican.lang" Name="Spanish Mexican.lang" DiskId="1" Source="../../translations/Spanish Mexican.lang" />
             <File Id="Hindi.lang" Name="Hindi.lang" DiskId="1" Source="../../translations/Hindi.lang" />
             <RegistryKey Root="HKMU" Key="Software\Classes\Directory\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\Directory\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\Directory\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Directory\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%1"' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Directory\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Directory\Background\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%V"' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\LibraryFolder\background\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%V"' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\Folder\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\Folder\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\Folder\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Folder\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Folder\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%1"' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\Drive\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\Drive\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\Drive\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Drive\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\Drive\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%1"' Type="string" />
             <RegistryKey Root="HKMU" Key="Software\Classes\*\shell\grepWin" />
-            <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin" Value="search with grepWin" Type="string" />
+            <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin" Value="Search with grepWin" Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin" Name="Icon" Value='[APPLICATIONFOLDER]grepWin.exe,-107' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin\command" Value='"[APPLICATIONFOLDER]grepWin.exe" /searchpath:"%1"' Type="string" />
             <RegistryValue Root="HKMU" Key="Software\Classes\*\shell\grepWin" Name="MultiSelectModel" Value='Player' Type="string" />

--- a/src/grepWin.cpp
+++ b/src/grepWin.cpp
@@ -70,19 +70,19 @@ static void RegisterContextMenu(bool bAdd)
     {
         std::wstring sIconPath = CStringUtils::Format(L"%s,-%d", CPathUtils::GetLongPathname(CPathUtils::GetModulePath()).c_str(), IDI_GREPWIN);
         std::wstring sExePath  = CStringUtils::Format(L"%s /searchpath:\"%%1\"", CPathUtils::GetLongPathname(CPathUtils::GetModulePath()).c_str());
-        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Directory\\shell\\grepWin", nullptr, REG_SZ, L"search with grepWin\0", sizeof(L"search with grepWin\0"));
+        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Directory\\shell\\grepWin", nullptr, REG_SZ, L"Search with grepWin\0", sizeof(L"Search with grepWin\0"));
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Directory\\shell\\grepWin", L"Icon", REG_SZ, sIconPath.c_str(), static_cast<DWORD>((sIconPath.size() + 1) * sizeof(WCHAR)));
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Directory\\shell\\grepWin\\Command", nullptr, REG_SZ, sExePath.c_str(), static_cast<DWORD>((sExePath.size() + 1) * sizeof(WCHAR)));
-        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Directory\\Background\\shell\\grepWin", nullptr, REG_SZ, L"search with grepWin", sizeof(L"search with grepWin") + 2);
+        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Directory\\Background\\shell\\grepWin", nullptr, REG_SZ, L"Search with grepWin", sizeof(L"Search with grepWin") + 2);
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Directory\\Background\\shell\\grepWin", L"Icon", REG_SZ, sIconPath.c_str(), static_cast<DWORD>((sIconPath.size() + 1) * sizeof(WCHAR)));
 
-        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Folder\\shell\\grepWin", nullptr, REG_SZ, L"search with grepWin", sizeof(L"search with grepWin") + 2);
+        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Folder\\shell\\grepWin", nullptr, REG_SZ, L"Search with grepWin", sizeof(L"Search with grepWin") + 2);
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Folder\\shell\\grepWin", L"Icon", REG_SZ, sIconPath.c_str(), static_cast<DWORD>((sIconPath.size() + 1) * sizeof(WCHAR)));
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Folder\\shell\\grepWin\\Command", nullptr, REG_SZ, sExePath.c_str(), static_cast<DWORD>((sExePath.size() + 1) * sizeof(WCHAR)));
-        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Drive\\shell\\grepWin", nullptr, REG_SZ, L"search with grepWin", sizeof(L"search with grepWin") + 2);
+        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Drive\\shell\\grepWin", nullptr, REG_SZ, L"Search with grepWin", sizeof(L"Search with grepWin") + 2);
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Drive\\shell\\grepWin", L"Icon", REG_SZ, sIconPath.c_str(), static_cast<DWORD>((sIconPath.size() + 1) * sizeof(WCHAR)));
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\Drive\\shell\\grepWin\\Command", nullptr, REG_SZ, sExePath.c_str(), static_cast<DWORD>((sExePath.size() + 1) * sizeof(WCHAR)));
-        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\*\\shell\\grepWin", nullptr, REG_SZ, L"search with grepWin", sizeof(L"search with grepWin") + 2);
+        SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\*\\shell\\grepWin", nullptr, REG_SZ, L"Search with grepWin", sizeof(L"Search with grepWin") + 2);
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\*\\shell\\grepWin", L"Icon", REG_SZ, sIconPath.c_str(), static_cast<DWORD>((sIconPath.size() + 1) * sizeof(WCHAR)));
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\*\\shell\\grepWin\\Command", nullptr, REG_SZ, sExePath.c_str(), static_cast<DWORD>((sExePath.size() + 1) * sizeof(WCHAR)));
         SHSetValue(HKEY_CURRENT_USER, L"Software\\Classes\\*\\shell\\grepWin", L"MultiSelectModel", REG_SZ, L"Player\0", sizeof(L"Player\0"));


### PR DESCRIPTION
First letter of each entry of the explorer context menu is always upper-case. Here an example from the French version of Windows, but English version is identical:
![image](https://user-images.githubusercontent.com/6498723/146684126-5375fd54-e182-490d-bf19-9177cae117e5.png)

The PR just transforms `search with grepWin` into `Search with grepWin` so that it's consistent.

The two Wix files are modified, as well as the GrepWin.cpp file that creates the registry entries (probably when called from the command line with a specific parameter, I didn't really get into the details).
Also changed dllmain.cpp as the same string is there, though I strictly don't have any clue about the impact :-)
