### PR TITLE
Update translations by application of existing translations

### DIFF
--- a/translations/Belarusian.lang
+++ b/translations/Belarusian.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld файлаў, прапушчана %ld файлаў. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Файлы"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Found %ld файлаў, прапушчана %ld файлаў."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "Знойдзена %ld файлаў, прапушчана %ld файла
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "Знойдзена %ld файлаў, прапушчана %ld файлаў. Ёсць %ld супадзенняў у %ld файлах. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Chinese.lang
+++ b/translations/Chinese.lang
@@ -138,7 +138,7 @@ msgstr "复制文件名称到剪贴板"
 
 #. Resource IDs: (146)
 msgid "Copy filenames to clipboard"
-msgstr ""复制文件名称到剪贴"
+msgstr "复制文件名称到剪贴"
 
 #. Resource IDs: (143)
 msgid "Copy path to clipboard"

--- a/translations/Chinese.lang
+++ b/translations/Chinese.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld 个文件, 已跳过 %ld 个文件. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "文件"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "已找到 %ld 个文件, 已跳过 %ld 个文件."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "已搜索 %ld 个文件, 已跳过 %ld 个文件. 已找到 %ld 个匹�
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "已搜索 %ld 个文件, 已跳过 %ld 个文件. 已找到 %ld 个匹配于 %ld 个文件中. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Dutch.lang
+++ b/translations/Dutch.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld bestanden, %ld bestanden overgeslagen. %ld resultaten geselecteerd."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Bestanden"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "%ld bestanden gevonden, %ld bestanden overgeslagen."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"

--- a/translations/French.lang
+++ b/translations/French.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld fichier(s). Ignoré %ld fichier(s). %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "fichiers"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Trouvé %ld fichier(s). Ignoré %ld fichier(s)."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -433,12 +433,12 @@ msgstr "Motif de recherche"
 #. Resource IDs: (128)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files."
-msgstr "Cherché dans %ld fichier(s). Ignoré %ld fichier(s). Trouvé %ld correspondance(s) dans %ld fichier(s)."   "
+msgstr "Cherché dans %ld fichier(s). Ignoré %ld fichier(s). Trouvé %ld correspondance(s) dans %ld fichier(s)."
 
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "Cherché dans %ld fichier(s). Ignoré %ld fichier(s). Trouvé %ld correspondance(s) dans %ld fichier(s). %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Greek.lang
+++ b/translations/Greek.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld αρχεία, παραβλέφτηκαν %ld αρχεία. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Αρχεία"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Βρέθηκαν %ld αρχεία, παραβλέφτηκαν %ld αρχεία."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "Ερευνήθηκαν %ld αρχεία, παραβλέφτηκαν %ld 
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "Ερευνήθηκαν %ld αρχεία, παραβλέφτηκαν %ld αρχεία. Βρέθηκαν %ld αντιστοιχίσεις σε %ld αρχεία. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Hindi.lang
+++ b/translations/Hindi.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld फ़ाइलें, %ld फ़ाइलें छोड़ीं। %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -438,7 +438,7 @@ msgstr "%ld फ़ाइलें खोजीं, %ld फ़ाइलें छोड़
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld फ़ाइलें खोजीं, %ld फ़ाइलें छोड़ीं। %ld फ़ाइलों में %ld मिलान नतीजे मिले %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Hungarian.lang
+++ b/translations/Hungarian.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld fájlban, kihagyva %ld fájl. %ld eredmény kiválasztva."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Fájlok"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Found %ld fájlban, kihagyva %ld fájl."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"

--- a/translations/Italian.lang
+++ b/translations/Italian.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld file, saltati %ld file. %ld risultati selezionati."
 
 # ONLY change the msgstr field. Do NOT change any other.
 # If you do not want to change an Accelerator Key, copy msgid to msgstr
@@ -237,7 +237,7 @@ msgstr "File"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Trovate %ld file, saltati %ld file."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"

--- a/translations/Korean.lang
+++ b/translations/Korean.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld 파일을 %ld 파일을 건너뜁니다. %ld 결과가 선택되었습니다."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "파일"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "%ld 파일을 찾았습니다 %ld 파일을 건너뜁니다."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"

--- a/translations/Polish.lang
+++ b/translations/Polish.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "Plików: %ld, pominięto plików: %ld. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Pliki"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Znaleziono plików: %ld, pominięto plików: %ld."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "Wyszukano plików: %ld, pominięto plików: %ld. Znaleziono %ld dopasowa
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "Wyszukano plików: %ld, pominięto plików: %ld. Znaleziono %ld dopasowań w %ld plikach. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Portuguese Brazilian.lang
+++ b/translations/Portuguese Brazilian.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld arquivos, %ld arquivos ignorados."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Arquivos"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "%ld arquivos localizados, %ld arquivos ignorados."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "%ld arquivos procurados, %ld arquivos ignorados. %ld localizados, %ld co
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld arquivos procurados, %ld arquivos ignorados. %ld localizados, %ld correspondentes. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Portuguese.lang
+++ b/translations/Portuguese.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld ficheiros, %ld ficheiros ignorados. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Ficheiros"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Encontradas %ld procurados, %ld ficheiros ignorados."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "%ld ficheiros procurados, %ld ficheiros ignorados. Encontradas %ld corre
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld ficheiros procurados, %ld ficheiros ignorados. Encontradas %ld correspondências em %ld ficheiros. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Russian.lang
+++ b/translations/Russian.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld файлов, пропущено %ld файлов. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Файлы"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Имеется %ld файлов, пропущено %ld файлов."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "Найдено %ld файлов, пропущено %ld файлов. И
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "Найдено %ld файлов, пропущено %ld файлов. Имеется %ld совпадений в %ld файлах. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Slovak.lang
+++ b/translations/Slovak.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld súborov, vynechané %ld súborov. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Súbory"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Našlo %ld súborov, vynechané %ld súborov."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "Prehľadané %ld súborov, vynechané %ld súborov. Našlo sa %ld výsky
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "Prehľadané %ld súborov, vynechané %ld súborov. Našlo sa %ld výskytov v %ld súboroch. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Spanish Mexican.lang
+++ b/translations/Spanish Mexican.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld archivos, y se omitieron %ld archivos. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Archivos"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Se encontraron %ld archivos, y se omitieron %ld archivos."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "Se buscó en %ld archivos, y se omitieron %ld archivos. Se encontraron %
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "Se buscó en %ld archivos, y se omitieron %ld archivos. Se encontraron %ld coincidencias en %ld archivos. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Spanish.lang
+++ b/translations/Spanish.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld archivos, omitidos %ld archivos. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Archivos"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Encontrade %ld archivos, omitidos %ld archivos."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "Busque %ld archivos, omitidos %ld archivos. Encontrade %ld coincidencias
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "Busque %ld archivos, omitidos %ld archivos. Encontrade %ld coincidencias en %ld archivos. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Swedish.lang
+++ b/translations/Swedish.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld filer, hoppade över %ld filer. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Filer"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "Hittade %ld filer, hoppade över %ld filer."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "Sök %ld filer, hoppade över %ld filer. Hittade %ld träffar i %ld file
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "Sök %ld filer, hoppade över %ld filer. Hittade %ld träffar i %ld filer. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."

--- a/translations/Turkish.lang
+++ b/translations/Turkish.lang
@@ -36,7 +36,7 @@ msgstr ""
 #. Resource IDs: (175)
 #, c-format
 msgid "%ld files, skipped %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld dosya, %ld dosya atlandı. %ld results selected."
 
 #. Resource IDs: (149)
 #, c-format
@@ -235,7 +235,7 @@ msgstr "Dosyalar"
 #. Resource IDs: (174)
 #, c-format
 msgid "Found %ld files, skipped %ld files."
-msgstr ""
+msgstr "%ld dosya bulundu, %ld dosya atlandı."
 
 #. Resource IDs: (109)
 msgid "GREPWIN"
@@ -438,7 +438,7 @@ msgstr "%ld dosya arandı, %ld dosya atlandı. %ld dosyalarında %ld eşleşmesi
 #. Resource IDs: (173)
 #, c-format
 msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."
-msgstr ""
+msgstr "%ld dosya arandı, %ld dosya atlandı. %ld dosyalarında %ld eşleşmesi bulundu. %ld results selected."
 
 #. Resource IDs: (140)
 msgid "Select Editor Application..."


### PR DESCRIPTION
Resource ID 174  and 175 can be derived from 128 and 173. 
Note that it is not in my native language. But probably not bad. Confirmation by each translator is necessary. I also checked using Google Translate.

There is a prototype for copying:
* Resource ID 173: ```msgid "Searched %ld files, skipped %ld files. Found %ld matches in %ld files. %ld results selected."```

Translation applied to:
* Resource ID 175: ```msgid "%ld files, skipped %ld files. %ld results selected."```
* Resource ID 174: ```msgid "Found %ld files, skipped %ld files."```
