### PR TITLE
change working directory on start

### DIFF
--- a/src/grepWin.cpp
+++ b/src/grepWin.cpp
@@ -219,13 +219,26 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
         } while ((hWnd == nullptr) && alreadyRunning && timeout);
     }
 
-    auto moduleName = CPathUtils::GetFileName(CPathUtils::GetModulePath(nullptr));
+    auto modulePath = CPathUtils::GetModuleDir(nullptr);
+
+    auto moduleName = CPathUtils::GetFileName(modulePath);
     bPortable       = ((wcsstr(moduleName.c_str(), L"portable")) || (parser.HasKey(L"portable")));
 
-    g_iniPath       = CPathUtils::GetModuleDir(nullptr);
+    g_iniPath       = modulePath;
     g_iniPath += L"\\grepwin.ini";
     if (parser.HasVal(L"inipath"))
         g_iniPath = parser.GetVal(L"inipath");
+
+    // attempt to change the working directory to the installation directory
+    //
+    // This is a helper when launching grepWin using context menus. When
+    // launching from a context menu, the working directory will be set to the
+    // folder grepWin has been invoked from. With the process now having an
+    // association with this directory, actively attempting to manipulate
+    // (e.g. move/delete) will fail due to an "in use" error. To allow users
+    // to freely manipulate their file systems (without having to close
+    // grepWin), change the working directory to the install path of grepWin.
+    _wchdir(modulePath.c_str());
 
     if (bPortable)
     {


### PR DESCRIPTION
When launching from a context menu, the working directory will be set to the folder grepWin has been invoked from. With the process now having an association with this directory, actively attempting to manipulate (e.g. move/delete) will fail due to an "in use" error. For example:

1. Create a new directory on the file system
2. Navigate into that directory
3. Right-click and select "Search with grepWin"
4. Attempt to delete the folder and observe that it fails:

![image](https://user-images.githubusercontent.com/1834509/236680991-ea29bda5-30e5-4b1d-b9bc-b149fe699d84.png)

To allow users to freely manipulate their file systems (without having to close grepWin), change the working directory to the install path of grepWin on start.