### PR TITLE
correct portable detection

### DIFF
--- a/src/grepWin.cpp
+++ b/src/grepWin.cpp
@@ -219,12 +219,11 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
         } while ((hWnd == nullptr) && alreadyRunning && timeout);
     }
 
-    auto modulePath = CPathUtils::GetModuleDir(nullptr);
-
-    auto moduleName = CPathUtils::GetFileName(modulePath);
+    auto moduleName = CPathUtils::GetFileName(CPathUtils::GetModulePath(nullptr));
     bPortable       = ((wcsstr(moduleName.c_str(), L"portable")) || (parser.HasKey(L"portable")));
 
-    g_iniPath       = modulePath;
+    auto moduleDir  = CPathUtils::GetModuleDir(nullptr);
+    g_iniPath       = moduleDir;
     g_iniPath += L"\\grepwin.ini";
     if (parser.HasVal(L"inipath"))
         g_iniPath = parser.GetVal(L"inipath");
@@ -239,7 +238,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
     // (e.g. move/delete) will fail due to an "in use" error. To allow users
     // to freely manipulate their file systems (without having to close
     // grepWin), change the working directory to the install path of grepWin.
-    _wchdir(modulePath.c_str());
+    _wchdir(moduleDir.c_str());
 
     if (bPortable)
     {


### PR DESCRIPTION
A previous change \[1\] adjusted some locals to share the module's directory between the global ini-path and to forward into a new working directory change (`_wchdir`); however, these changes broken the portable detection logic by mixing up the usage of `GetModuleDir` and `GetModulePath`.

This commit restores the use of `GetModulePath` for the portable check, as well as adjusts the call to `GetModuleDir` to populate a variable named `moduleDir` (instead of `modulePath`; which most likely caused the incorrect optimization).

\[1\]: 65d06ce3d532dfda880edd764f79b1e43b69c668

----

With these changes:
- Built an executable.
- Renamed the executable to include a portable tag.
- Opened the executable and closed to observed the created ini file.
- Edited the ini file to enable an option (e.g. UTF-8).
- Re-opened the executable and observed the INI loading as expected with the changed option.