### PR TITLE
ignore windows system directory as a fallback search-path

### DIFF
--- a/src/grepWin.cpp
+++ b/src/grepWin.cpp
@@ -229,7 +229,30 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
     if (parser.HasVal(L"inipath"))
         g_iniPath = parser.GetVal(L"inipath");
 
-    auto origCwd = CPathUtils::GetCWD();
+    // extract the current working directory (before it can be changed
+    // below) as a fallback directory for the target search path (if
+    // a path is not explicitly provided in the arguments)
+    std::wstring targetCwd = CPathUtils::GetCWD();
+
+    // ignore a system directory fallback path
+    //
+    // grepWin will fallback onto the working directory if not path
+    // argument is provided from the command line. This can lead to
+    // search path being unexpectedly configured to the Window's
+    // System32 path when a "pinned" (or start-menu-invoked) grepWin
+    // is launch (since Explorer's working directory is the system
+    // path). In these cases, having the search path fall back to
+    // the last directory saved (in the registry) can be preferred;
+    // so if a Windows system path is detected, ignore it.
+    WCHAR systemDirectory[MAX_PATH + 1] = {0};
+    if (GetSystemDirectoryW(systemDirectory, MAX_PATH) > 0)
+    {
+        if (!targetCwd.compare(systemDirectory))
+        {
+            targetCwd = L"";
+        }
+    }
+
     // attempt to change the working directory to the installation directory
     //
     // This is a helper when launching grepWin using context menus. When
@@ -252,7 +275,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
         bool bOnlyOne = !!static_cast<DWORD>(CRegStdDWORD(L"Software\\grepWin\\onlyone", 0));
         if (bPortable)
             bOnlyOne = !!_wtoi(g_iniFile.GetValue(L"global", L"onlyone", L"0"));
-        auto sPath = parser.GetVal(L"searchpath") ? parser.GetVal(L"searchpath") : origCwd;
+        auto sPath = parser.GetVal(L"searchpath") ? parser.GetVal(L"searchpath") : targetCwd;
         sPath      = SanitizeSearchPaths(sPath);
         SearchReplace(sPath, L"/", L"\\");
         sPath = SanitizeSearchPaths(sPath);
@@ -515,7 +538,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
                 }
                 else
                 {
-                    auto sPath = origCwd;
+                    auto sPath = targetCwd;
                     sPath      = SanitizeSearchPaths(sPath);
                     searchDlg.SetSearchPath(sPath);
                 }


### PR DESCRIPTION
# Prelude
Noticed when using the most recent version of grepWin, when I triggered a start using a pinned taskbar shortcut, grepWin would always present the Windows system directory as the default search path. Previous versions would default to the last search path used (stored in the registry). Noticed that changes were made in the recent implementation to fallback on the working directory (maybe to support invoking grepWin from command line?). Figured this hack may be preferred to deal with start-menu/pinned starts; however, I'm not sure if I am overlooking any other use cases.

# Change note
Changes have been introduced into grepWin where the current working directory is used as fallback search path to use when no path is provided from the command line/context-menu invoke. A possible undesired effect from this change is that when grepWin is invoked from a taskbar pin or the start-menu, the default working directory will be the Windows system path. Users starting grepWin without a possible target directory are no longer presented with the last saved search folder.

This commit attempts to allow users to still fallback to the last searched folder by ignoring the case where the system directory is detected as the current working directory.

An undesired effect of this change is that if a user was in the system path and invoked grepWin without a path argument, they would not be presented an instance where the search path matched their working directory (note: context-menu invokes still work as expected). While this may be undesired, it is assumed that the probability of that use case is significantly smaller than a user invoking grepWin from a pinned taskbar.