### PR TITLE
change .gitattributes encoding UTF-16 to UTF-8 and set it for lang files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
-/src/Resources/grepWin.rc2  text working-tree-encoding=UTF-16
-/src/Resources/grepWin.rc   text working-tree-encoding=UTF-16
-/src/resource.h             text working-tree-encoding=UTF-16
+/src/Resources/grepWin.rc   text working-tree-encoding=UTF-8
+/src/Resources/grepWin.rc2  text working-tree-encoding=UTF-8
+/src/resource.h             text working-tree-encoding=UTF-8
+/translations/*.lang        text working-tree-encoding=UTF-8

--- a/src/Resources/grepWin.rc
+++ b/src/Resources/grepWin.rc
@@ -1,5 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "..\resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS

--- a/src/Resources/grepWin.rc2
+++ b/src/Resources/grepWin.rc2
@@ -1,4 +1,4 @@
-//
+﻿//
 // grepWin.rc2 - resources Microsoft Visual C++ does not edit directly
 //
 

--- a/src/resource.h
+++ b/src/resource.h
@@ -1,4 +1,4 @@
-//{{NO_DEPENDENCIES}}
+﻿//{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by D:\Development\grepWin\src\Resources\grepWin.rc
 //


### PR DESCRIPTION
For UTF-16, git converts back to UTF-16BE BOM, but MSVC silently takes it without error.
MSVC compiler recognizes UTF-8 BOM.
VS2022 stores UTF-8 rc file with `#pragma code_page(65001)` instead of BOM.

My bad. I recalled the binaries was good, during several times hard reset.
Now, it has been tested by Build Tools with `cl` v19.33.31630 and VS2022 v17.8.6 with `cl` v19.38.33135.
