### PR TITLE
fix item width for AutoSizeAllColumns excluding the vertical scroll bar

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -4525,7 +4525,8 @@ void CSearchDlg::AutoSizeAllColumns()
     {
         RECT rc{};
         ListView_GetItemRect(hListControl, 0, &rc, LVIR_BOUNDS);
-        auto itemWidth = rc.right - rc.left;
+        int cxVScroll   = GetSystemMetrics(SM_CXVSCROLL);
+        auto itemWidth  = rc.right - rc.left - cxVScroll;
         if (nItemCount > 0)
         {
             GetClientRect(hListControl, &rc);


### PR DESCRIPTION
Scenario:
Start a new instance, search something that will get a long list of results (content mode).
It triggers the vertical scroll bar show up, and then the horizontal scroll bar too.
