### PR TITLE
AutoSizeAllColumns for each search

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -4524,16 +4524,8 @@ void CSearchDlg::AutoSizeAllColumns()
     if (!fileList)
     {
         RECT rc{};
-        ListView_GetItemRect(hListControl, 0, &rc, LVIR_BOUNDS);
+        GetClientRect(hListControl, &rc);   // excludes the vertical scroll bar
         auto itemWidth = rc.right - rc.left;
-        if (nItemCount > 0)
-        {
-            GetClientRect(hListControl, &rc);
-            if (itemWidth < rc.right - rc.left)
-            {
-                itemWidth = rc.right - rc.left;
-            }
-        }
         auto totalWidth = std::accumulate(colWidths.begin(), colWidths.end(), 0);
         totalWidth -= colWidths[colWidths.size() - 2];
         auto textWidth = itemWidth - totalWidth;


### PR DESCRIPTION
Mutex to https://github.com/stefankueng/grepWin/pull/453. I prefer this one.

* `GetClientRect` automatically excludes the vertical scroll bar
 width
* users may hope to resize the last expanded text column, from manual or restore down from max window